### PR TITLE
Refactors Corpus.search method for current and future sampling

### DIFF
--- a/languagechange/corpora.py
+++ b/languagechange/corpora.py
@@ -91,7 +91,14 @@ class Line:
         else:
             raise ValueError(f"'{feat}' is not a valid word feature")
 
-    def search(self, search_term : SearchTerm, time = None) -> List[TargetUsage]:
+    def search(self, search_term : SearchTerm, time = None) -> TargetUsageList:
+        """
+            Searches the line given a search_term.
+
+            Args:
+                search_term : SearchTerm
+            Returns: A TargetUsageList of all matches.
+        """
         tul = TargetUsageList()
         for feat in search_term.word_feature:
             if search_term.regex:
@@ -145,6 +152,17 @@ class Corpus:
     def search(self,
                search_terms: List[ str | Pattern | SearchTerm ]
                ) -> UsageDictionary:
+        """
+            Searches through the corpora by calling Line.search() on all lines.
+
+            Args:
+                search_terms : List[ str | Pattern | SearchTerm ]
+                    If a search term is str or Pattern it is converted
+                    to a SearchTerm and matches tokens only
+                    SearchTerm(word_feature = 'token').
+
+            Returns: A UsageDictionary containing all search results for each search term.
+        """
 
         usage_dictionary = UsageDictionary()
         n_usages = 0
@@ -929,22 +947,27 @@ class HistoricalCorpus(SortedKeyList):
             except:
                 logging.error(f"Could not get lines from {corpus.name}.")
 
-    def search(self, words : List[str], strategy='REGEX', search_func=None, index_by_corpus=False):
+
+    def search(self, search_terms : List[ str | Pattern | SearchTerm ], index_by_corpus=False):
         """
             Searches through all of the corpora by calling search() for each of them.
 
             Args:
-                words ([str]): a list of the words to be searched, passed to Corpus.search().
-                strategy (str|[str], default='REGEX'): the strategy to use when searching, passed to Corpus.search().
-                search_func (function, default=None): a custom search function, passed to Corpus.search().
-                index_by_corpus (bool, default=False): decides whether the usages for a given word should be a dictionary, with keys as the corpus names and values as lists of usages, or a list of all usages across corpora.
+                search_terms : List[ str | Pattern | SearchTerm ]
+                    If search term is str or Pattern it is converted
+                    to a SearchTerm and matches tokens only
+                    SearchTerm(word_feature = 'token').
+                index_by_corpus : bool, default False
+                    decides whether the usages for a given word should be a dictionary,
+                    with keys as the corpus names and values as lists of usages, or a list
+                    of all usages across corpora.
 
             Returns: a dictionary containing all search results from the included corpora.
         """
         usages = {}
         for corpus in self:
             try:
-                usage_dict = corpus.search(words, strategy=strategy, search_func=search_func)
+                usage_dict = corpus.search(search_terms)
             except:
                 logging.error(f"Could not search through {corpus.name}.")
                 continue

--- a/languagechange/corpora.py
+++ b/languagechange/corpora.py
@@ -121,8 +121,8 @@ class Line:
                     if search_term.term == token:
                         offsets = [0,0]
                         if not idx == 0:
-                            offsets[0] = len(' '.join(token_features[:idx])) + 1
-                        offsets[1] = offsets[0] + len(token_features[idx])
+                            offsets[0] = len(' '.join(self.tokens()[:idx])) + 1
+                        offsets[1] = offsets[0] + len(self.tokens()[idx])
                         tu = TargetUsage(self.raw_text(), offsets, time, id=self.id)
                         tul.append(tu)
         return tul

--- a/languagechange/corpora.py
+++ b/languagechange/corpora.py
@@ -1,18 +1,17 @@
 import bz2
-import os
 import gzip
-import random
-from languagechange.resource_manager import LanguageChange
-from languagechange.search import SearchTerm
-from languagechange.usages import Target, TargetUsage, TargetUsageList, UsageDictionary
-import re
-from languagechange.utils import LiteralTime, NumericalTime, TimeInterval
-from sortedcontainers import SortedKeyList
 import logging
+import os
+import re
+from typing import List, Pattern, Self, Union
+
 import lxml.etree as ET
 import trankit
-from typing import Callable, List, Union, Self, Pattern
-import datetime
+from languagechange.resource_manager import LanguageChange
+from languagechange.search import SearchTerm
+from languagechange.usages import TargetUsage, TargetUsageList, UsageDictionary
+from languagechange.utils import LiteralTime
+from sortedcontainers import SortedKeyList
 
 logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
 
@@ -144,10 +143,8 @@ class Corpus:
             self.time = time
         self.skip_lines = skip_lines
 
-
     def set_sentences_iterator(self, sentences):
         self.sentences_iterator = sentences
-
 
     def search(self,
                search_terms: List[ str | Pattern | SearchTerm ]
@@ -223,7 +220,6 @@ class Corpus:
                             yield line
                 except Exception:
                     logging.error(f"Could not use tokenizer {tokenizer} directly as a function to tokenize.")
-
 
     def lemmatize(self, lemmatizer = "trankit", pretokenized = False, tokenize = False, split_sentences = False, batch_size=128):
         if lemmatizer == "trankit":
@@ -308,7 +304,6 @@ class Corpus:
                                 yield line
                 except Exception:
                     logging.error(f"Could not use method {lemmatizer} directly as a function to lemmatize.")
-    
 
     def pos_tagging(self, pos_tagger = "trankit", pretokenized = False, tokenize=False, split_sentences = False, batch_size=128):
         if pos_tagger == "trankit":
@@ -392,7 +387,6 @@ class Corpus:
                 except Exception:
                     logging.error(f"Could not use method {pos_tagger} directly as a function to perform POS tagging.")
 
-
     def tokens_lemmas_pos_tags(self, nlp_model="trankit", tokens=True, split_sentences = False, batch_size=128):
         if nlp_model == "trankit":
             p = trankit.Pipeline(self.language)
@@ -434,7 +428,6 @@ class Corpus:
                 if len(texts) != 0:
                     for line in process_texts(texts):
                         yield line
-
 
     # preliminary function
     def segment_sentences(self, segmentizer = "trankit", batch_size=128):
@@ -507,11 +500,9 @@ class Corpus:
                 else:
                     iterate = False
 
-
     def save(self):
         lc = LanguageChange()
-        path = lc.save_resource('corpus',f'{self.language} corpora',self.name)
-
+        lc.save_resource('corpus',f'{self.language} corpora',self.name)
 
     def save_tokenized_corpora(corpora : Union[Self, List[Self]], tokens = True, lemmas = False, pos = False, save_format = 'linebyline', file_specification = None, file_ending = ".txt", tokenizer="trankit", lemmatizer="trankit", pos_tagger="trankit", split_sentences = True, batch_size=128):
         if not type(corpora) is list:
@@ -614,7 +605,6 @@ class LinebyLineCorpus(Corpus):
             else:
                 self.is_lemmatized = False
 
-
     def line_iterator(self):
         
         if os.path.isdir(self.path):
@@ -660,7 +650,6 @@ class VerticalCorpus(Corpus):
         self.sentence_separator = sentence_separator
         self.field_separator = field_separator
         self.field_map = field_map
-
 
     def line_iterator(self):
         
@@ -822,7 +811,6 @@ class XMLCorpus(Corpus):
             else:
                 raise Exception('Format not recognized')
 
-    
     # Cast to a LineByLine corpus and save the result in the path specified in there
     def cast_to_linebyline(self, linebyline_corpus : LinebyLineCorpus):
         savepath = linebyline_corpus.path
@@ -845,7 +833,6 @@ class XMLCorpus(Corpus):
             else:
                 for line in self.line_iterator():
                     f.write(line.raw_text()+'\n')  # cache needed here
-
 
     def cast_to_vertical(self, vertical_corpus : VerticalCorpus):
         savepath = vertical_corpus.path
@@ -870,7 +857,6 @@ class SprakBankenCorpus(XMLCorpus):
 
     def __init__(self, path, sentence_tag='sentence',token_tag='token', is_lemmatized=True, lemma_tag='lemma', is_pos_tagged=True, pos_tag_tag='pos', **args):
         super().__init__(path, sentence_tag, token_tag, is_lemmatized, lemma_tag, is_pos_tagged, pos_tag_tag, **args)
-
     
     def get_attribute(self, tag, attribute):
         content = tag.attrib[attribute]
@@ -882,7 +868,6 @@ class SprakBankenCorpus(XMLCorpus):
             else:
                 return content
         return tag.text
-
 
 
 class HistoricalCorpus(SortedKeyList):
@@ -934,7 +919,6 @@ class HistoricalCorpus(SortedKeyList):
             logging.error("'corpora' needs to be either a string or a list of Corpus objects.")
             raise Exception
         super().__init__(corpora, key)
-        
 
     def line_iterator(self):
         """
@@ -946,7 +930,6 @@ class HistoricalCorpus(SortedKeyList):
                     yield line
             except:
                 logging.error(f"Could not get lines from {corpus.name}.")
-
 
     def search(self, search_terms : List[ str | Pattern | SearchTerm ], index_by_corpus=False):
         """

--- a/languagechange/search.py
+++ b/languagechange/search.py
@@ -1,0 +1,15 @@
+from typing import List, Set
+
+def expand_dictionary(words: List[str]):
+    raise NotImplementedError
+
+class SearchTerm():
+
+    VALID_WORD_FEATURES = ['lemma', 'token', 'pos']
+
+    def __init__(self, term : str, regex : bool = False, word_feature : str | Set = 'token'):
+        self.term = term 
+        self.regex = regex
+        self.word_feature = word_feature if isinstance(word_feature, Set) else {word_feature}
+        if not word_feature.issubset(self.VALID_WORD_FEATURES):
+            raise ValueError("'word_feature' must be set to one of the following values: ", self.VALID_WORD_FEATURES)

--- a/languagechange/search.py
+++ b/languagechange/search.py
@@ -11,5 +11,5 @@ class SearchTerm():
         self.term = term 
         self.regex = regex
         self.word_feature = word_feature if isinstance(word_feature, Set) else {word_feature}
-        if not word_feature.issubset(self.VALID_WORD_FEATURES):
+        if not self.word_feature.issubset(self.VALID_WORD_FEATURES):
             raise ValueError("'word_feature' must be set to one of the following values: ", self.VALID_WORD_FEATURES)

--- a/languagechange/usages.py
+++ b/languagechange/usages.py
@@ -2,6 +2,9 @@ import enum
 import pickle
 from pathlib import Path
 import os
+
+import jsonlines
+
 from languagechange.utils import Time
 
 
@@ -10,6 +13,7 @@ class POS(enum.Enum):
    VERB = 2
    ADJECTIVE = 3
    ADVERB = 4
+
 
 class Target:
     def __init__(self, target : str):
@@ -26,6 +30,7 @@ class Target:
 
     def __hash__(self):
         return hash(self.target)
+
 
 class TargetUsage:
     def __init__(self, text: str, offsets: str, time: Time = None, **args):
@@ -45,11 +50,17 @@ class TargetUsage:
     def time(self):
         return self.time
 
+    def to_dict(self):
+        d = self.__dict__
+        d['time'] = str(d['time'])
+        return d
+
     def __getitem__(self,item):
         return self.text_[item]
 
     def __str__(self):
         return self.text_
+
 
 class DWUGUsage(TargetUsage):
 
@@ -75,3 +86,15 @@ class TargetUsageList(list):
 
     def time_axis(self):
         return [usage.time for usage in self]
+
+    def to_dict(self):
+        return [tu.to_dict() for tu in self]
+
+
+class UsageDictionary(dict):
+
+    def save(self, path):
+        Path(path).mkdir(parents=True, exist_ok=True)
+        for k in self:
+            with jsonlines.open(f"{path}/{k}_usages.jsonl", 'w') as writer:
+                writer.write_all(self[k].to_dict())

--- a/languagechange/usages.py
+++ b/languagechange/usages.py
@@ -1,9 +1,11 @@
 import enum
 import pickle
-from pathlib import Path
+import logging
 import os
 
 import jsonlines
+
+from pathlib import Path
 
 from languagechange.utils import Time
 
@@ -33,10 +35,11 @@ class Target:
 
 
 class TargetUsage:
-    def __init__(self, text: str, offsets: str, time: Time = None, **args):
+    def __init__(self, text: str, offsets: str, time: Time = None, **kwargs):
         self.text_ = text
         self.offsets = offsets
         self.time = time
+        self.__dict__.update(kwargs)
 
     def text(self):
         return self.text_
@@ -96,5 +99,7 @@ class UsageDictionary(dict):
     def save(self, path):
         Path(path).mkdir(parents=True, exist_ok=True)
         for k in self:
-            with jsonlines.open(f"{path}/{k}_usages.jsonl", 'w') as writer:
+            output_fn = f"{path}/{k}_usages.jsonl"
+            with jsonlines.open(output_fn, 'w') as writer:
                 writer.write_all(self[k].to_dict())
+                logging.info(f"Usages written to {output_fn}")


### PR DESCRIPTION
This pull request refactors the `corpora.Corpus.search` method and makes it more extendable for more complicated and user-friendly search queries in the future. Additionally, it allows the user to save the search results into a `.json` file. An example of using this can be found at:

https://github.com/felixhultin/sampling-for-literary-studies

The new `corpora.Corpus.search` method takes a list of search terms (`SearchTerm`) which match the words by either direct string matching or regex against a defined set of word features, which at the moment are only the already supported features part-of-speech, lemma and token but can be extended in the future.

This pull request also does some style cleaning of the code in `corpora.py`.