### PR TITLE
Computational annotation

### DIFF
--- a/languagechange/benchmark.py
+++ b/languagechange/benchmark.py
@@ -1,23 +1,16 @@
-from languagechange.resource_manager import LanguageChange
-from languagechange.corpora import LinebyLineCorpus
-from languagechange.models.representation.contextualized import ContextualizedModel
-from languagechange.models.representation.definition import DefinitionGenerator
-from languagechange.models.representation.prompting import PromptModel
-from languagechange.usages import Target, TargetUsage, TargetUsageList, DWUGUsage
-from languagechange.utils import NumericalTime, LiteralTime
-from languagechange.models.meaning.clustering import Clustering, CorrelationClustering
-import webbrowser
 import os
-import pickle
-import json
 from itertools import islice
-import logging
 import re
-import zipfile
+import json
 import random
-import numpy as np
+import webbrowser
+import pickle
 import math
+from math import comb
 import csv
+import logging
+import zipfile
+import numpy as np
 from scipy.stats import spearmanr
 from sklearn.metrics import accuracy_score, f1_score, adjusted_rand_score
 import lxml.etree as ET
@@ -29,7 +22,14 @@ import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.cm
 import matplotlib.colors
-from math import comb
+from languagechange.resource_manager import LanguageChange
+from languagechange.corpora import LinebyLineCorpus
+from languagechange.models.representation.contextualized import ContextualizedModel
+from languagechange.models.representation.definition import DefinitionGenerator
+from languagechange.models.representation.prompting import PromptModel
+from languagechange.usages import Target, TargetUsage, TargetUsageList, DWUGUsage
+from languagechange.utils import NumericalTime, LiteralTime
+from languagechange.models.meaning.clustering import Clustering, CorrelationClustering
 
 
 def purity(labels_true, cluster_labels):

--- a/languagechange/models/meaning/clustering.py
+++ b/languagechange/models/meaning/clustering.py
@@ -384,6 +384,19 @@ class APosterioriaffinityPropagation(ClusterMixin, BaseEstimator):
                 tot += len(values)
         return tot
     
+""" 
+The CorrelationClustering and Loss classes below use code from 
+https://github.com/Garrafao/correlation_clustering/blob/main/src/correlation.py
+
+Corresponding papers / theses:
+
+Dominik Schlechtweg, Nina Tahmasebi, Simon Hengchen, Haim Dubossarsky, Barbara McGillivray. 2021. 
+DWUG: A large Resource of Diachronic Word Usage Graphs in Four Languages. 
+In Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing.
+
+Dominik Schlechtweg. 2023. Human and Computational Measurement of Lexical Semantic Change. 
+PhD thesis. University of Stuttgart.
+"""
 
 class CorrelationClustering():
     def __init__(self, s = 10, max_attempts = 200, max_iters = 5000, initial = [], split_flag = True):
@@ -396,7 +409,9 @@ class CorrelationClustering():
     def fit_predict(self, similarity_graph : nx.classes.graph.Graph):
         """
             Args:
-                similarity_graph (networkx.classes.graph.Graph) : a graph where each node is the id of a usage and each edge is a similarity between two usages (>0 for positive edges and <0 for negative edges)
+                similarity_graph (networkx.classes.graph.Graph) : a graph where each node is the id 
+                    of a usage and each edge is a similarity between two usages (>0 for positive 
+                    edges and <0 for negative edges)
         """
         for init in range(5):
             classes, _ = self.cluster_correlation_search(
@@ -422,7 +437,6 @@ class CorrelationClustering():
                 node2cluster[node] = c_idx
         return node2cluster
 
-    # Code below from Garrafao/cluster_correlation_search
     def cluster_correlation_search(self, G, s = 10, max_attempts = 200, max_iters = 5000, initial = [], split_flag = True):
         """
         Apply correlation clustering. Assumes that negative edges have weights < 0, and positive edges have weights >= 0, that edges with nan have been removed and that weights are stored under edge attribute G[i][j]['weight'].

--- a/languagechange/models/meaning/clustering.py
+++ b/languagechange/models/meaning/clustering.py
@@ -399,7 +399,7 @@ PhD thesis. University of Stuttgart.
 """
 
 class CorrelationClustering():
-    def __init__(self, s = 10, max_attempts = 200, max_iters = 5000, initial = [], split_flag = True):
+    def __init__(self, s = 10, max_attempts = 2000, max_iters = 50000, initial = [], split_flag = True):
         self.s = s
         self.max_attempts = max_attempts
         self.max_iters = max_iters
@@ -413,13 +413,14 @@ class CorrelationClustering():
                     of a usage and each edge is a similarity between two usages (>0 for positive 
                     edges and <0 for negative edges)
         """
-        for init in range(5):
+        classes = self.initial
+        for _ in range(5):
             classes, _ = self.cluster_correlation_search(
                 similarity_graph, 
                 s=self.s,
                 max_attempts=self.max_attempts,
                 max_iters=self.max_iters,
-                initial=self.initial,
+                initial=classes,
                 split_flag=self.split_flag
             )
         node2cluster = self.classes_to_node2cluster(classes)

--- a/languagechange/models/meaning/clustering.py
+++ b/languagechange/models/meaning/clustering.py
@@ -2,9 +2,20 @@ import numpy as np
 from sklearn.cluster import AffinityPropagation
 from sklearn.base import ClusterMixin, BaseEstimator
 from sklearn.metrics.pairwise import euclidean_distances, cosine_similarity
-import networkx
-# TEMPORARY import, needs a proper installation from requirements.txt
-from correlation import cluster_correlation_search
+import sys
+from itertools import combinations, product, chain
+from collections import defaultdict, Counter
+import random
+import networkx as nx
+import numpy as np
+from scipy.stats import spearmanr
+from networkx.algorithms.dag import transitive_closure
+import mlrose_hiive
+import six
+sys.modules['sklearn.externals.six'] = six
+import time
+from scipy.optimize import linear_sum_assignment
+import multiprocessing as mp
 
 
 class ClusteringResults():
@@ -382,6 +393,24 @@ class CorrelationClustering():
         self.initial = initial
         self.split_flag = split_flag
 
+    def fit_predict(self, similarity_graph : nx.classes.graph.Graph):
+        """
+            Args:
+                similarity_graph (networkx.classes.graph.Graph) : a graph where each node is the id of a usage and each edge is a similarity between two usages (>0 for positive edges and <0 for negative edges)
+        """
+        for init in range(5):
+            classes, _ = self.cluster_correlation_search(
+                similarity_graph, 
+                s=self.s,
+                max_attempts=self.max_attempts,
+                max_iters=self.max_iters,
+                initial=self.initial,
+                split_flag=self.split_flag
+            )
+        node2cluster = self.classes_to_node2cluster(classes)
+        labels = [node2cluster[n] for n in list(similarity_graph.nodes)]
+        return labels
+
     def classes_to_node2cluster(self, classes):
         """
         classes: list of sets, each set is a cluster of node IDs.
@@ -393,20 +422,236 @@ class CorrelationClustering():
                 node2cluster[node] = c_idx
         return node2cluster
 
-    def fit_predict(self, similarity_graph : networkx.classes.graph.Graph):
+    # Code below from Garrafao/cluster_correlation_search
+    def cluster_correlation_search(self, G, s = 10, max_attempts = 200, max_iters = 5000, initial = [], split_flag = True):
         """
-            Args:
-                similarity_graph (networkx.classes.graph.Graph) : a graph where each node is the id of a usage and each edge is a similarity between two usages (>0 for positive edges and <0 for negative edges)
+        Apply correlation clustering. Assumes that negative edges have weights < 0, and positive edges have weights >= 0, that edges with nan have been removed and that weights are stored under edge attribute G[i][j]['weight'].
+
+        :param G: graph
+        :param s: maximal number of clusters assumed (has strong influence on runtime)
+        :param max_attempts: number of restarts for optimization
+        :param max_iters: number of iterations for optimization
+        :param initial: optional clustering for initialization
+        :param split_flag: optional flag, if non evidence cluster should be splitted
+        :return classes, stats: list of clusters, list of stats
         """
-        for init in range(5):
-            classes, _ = cluster_correlation_search(
-                similarity_graph, 
-                s=self.s,
-                max_attempts=self.max_attempts,
-                max_iters=self.max_iters,
-                initial=self.initial,
-                split_flag=self.split_flag
-            )
-        node2cluster = self.classes_to_node2cluster(classes)
-        labels = [node2cluster[n] for n in list(similarity_graph.nodes)]
-        return labels
+    
+        start_time = time.time()    
+        stats = {}
+        G = G.copy()
+
+        if initial == []: # initialize with connected components unless initial clustering is provided
+            classes = self.cluster_connected_components(G)
+        else:
+            classes = initial
+
+        n2i = {node:i for i, node in enumerate(G.nodes())}
+        i2n = {i:node for i, node in enumerate(G.nodes())}
+        n2c = {n2i[node]:i for i, cluster in enumerate(classes) for node in cluster}
+    
+        edges_positive = set([(n2i[i],n2i[j],G[i][j]['weight']) for (i,j) in G.edges() if G[i][j]['weight'] >= 0.0])
+        edges_negative = set([(n2i[i],n2i[j],G[i][j]['weight']) for (i,j) in G.edges() if G[i][j]['weight'] < 0.0])
+        
+        Linear_loss = Loss('linear_loss', edges_positive=edges_positive, edges_negative=edges_negative)
+        #conflict_loss = test_loss
+        
+        # Define initial state
+        init_state = np.array([n2c[n] for n in sorted(n2c.keys())])
+        loss_init = Linear_loss.loss(init_state)
+
+        if loss_init == 0.0:
+            #print('loss_init: ', loss_init)
+            classes.sort(key=lambda x:-len(x)) # sort by size
+            end_time = time.time()
+            stats = stats | {'s':s, 'max_attempts':max_attempts, 'max_iters':max_iters, 'split_flag':split_flag, 'runtime':(end_time - start_time)/60, 'loss':loss_init} 
+            return classes, stats
+
+        l2s = defaultdict(lambda: [])
+        l2s[loss_init].append((init_state,len(classes)))
+
+        # Initialize multiprocessing.Pool()
+        pool = mp.Pool(mp.cpu_count())
+        #pool = mp.Pool(1)
+        #print(mp.cpu_count())
+
+        # `pool.apply`
+        solutions = pool.starmap(Linear_loss.optimize_simulated_annealing, [(n, classes, G.nodes(), init_state, max_attempts, max_iters) for n in range(2,s)])
+        pool.close()    
+        #print(solutions[0])
+        
+        # Merge solutions
+        for l2s_ in solutions:
+            #print(l2s_)
+            for (l,ss) in l2s_.items():        
+                for st in ss:        
+                    l2s[l].append(st)
+
+        #print(l2s.values())
+
+        id = np.random.choice(range(len(l2s[min(l2s.keys())])))
+        best_state, best_fitness = l2s[min(l2s.keys())][id], min(l2s.keys())
+        #print('loss: ', best_fitness)
+
+        #print(best_state)
+        best_state = best_state[0]
+        #print(best_state)
+        
+        c2n = defaultdict(lambda: [])
+        for i, c in enumerate(best_state):
+            c2n[c].append(i2n[i])
+
+        classes = [set(c2n[c]) for c in c2n]
+
+        # Split collapsed clusters without evidence
+        if split_flag: classes = self.split_non_evidence_clusters(G, classes)
+
+        classes.sort(key=lambda x:-len(x)) # sort by size
+
+        end_time = time.time()
+        stats = stats | {'s':s, 'max_attempts':max_attempts, 'max_iters':max_iters, 'split_flag':split_flag, 'runtime':(end_time - start_time)/60, 'loss':best_fitness} 
+        
+        #print(stats['runtime'])
+        
+        return classes, stats
+        
+    def cluster_connected_components(self, G, is_non_value=lambda x: np.isnan(x)):
+        """
+        Apply connected_component clustering.       
+        :param G: graph
+        :return classes: list of clusters
+        """
+
+        G = G.copy()
+
+        edges_negative = [(i,j) for (i,j) in G.edges() if G[i][j]['weight'] < 0.0 or is_non_value(G[i][j]['weight'])]
+        G.remove_edges_from(edges_negative)
+        components = nx.connected_components(G)
+        classes = [set(component) for component in components]
+        classes.sort(key=lambda x:list(x)[0])
+
+        return classes
+
+
+    def split_non_evidence_clusters(self, G, clusters, is_non_value=lambda x: np.isnan(x)):
+        """
+        Split non-positively-connected components.       
+        :param G: graph
+        :param clusters: list of clusters
+        :return G: 
+        """
+
+        G = G.copy()
+        
+        nodes_in = [node for cluster in clusters for node in cluster]
+        edges_negative = [(i,j) for (i,j) in G.edges() if G[i][j]['weight'] < 0.0 or is_non_value(G[i][j]['weight'])]
+        G.remove_edges_from(edges_negative) # treat non-edges as non-comparisons
+
+        classes_out = []
+        for cluster in clusters:
+            subgraph = G.subgraph(cluster)
+            components = self.cluster_connected_components(subgraph)
+            for class_ in components:
+                classes_out.append(set(class_))
+        
+        # check that nodes stayed the same
+        nodes_out = [node for class_ in classes_out for node in class_]
+        if set(nodes_in) != set(nodes_out):
+            sys.exit('Breaking: nodes_in != nodes_out.')
+        if len(nodes_in) != len(nodes_out):
+            sys.exit('Breaking: len(nodes_in) != len(nodes_out).')
+        
+        return classes_out
+
+
+class Loss(object):
+    """
+    """
+    
+    def __init__(self, fitness_fn, edges_positive=None, edges_negative=None, edges_min=None, edges_max=None, signs=None):
+
+        self.edges_positive = edges_positive
+        self.edges_negative = edges_negative
+        self.edges_min = edges_min
+        self.edges_max = edges_max
+        self.signs = signs
+        if fitness_fn == 'test_loss':
+            self.fitness_fn = self.test_loss
+        if fitness_fn == 'linear_loss':
+            self.fitness_fn = self.linear_loss
+        if fitness_fn == 'binary_loss':
+            self.fitness_fn = self.binary_loss
+        if fitness_fn == 'binary_loss_poles':
+            self.fitness_fn = self.binary_loss_poles
+
+    def loss(self, state):        
+        return self.fitness_fn(state)
+
+    def test_loss(self, state):        
+        return 50.0
+
+    def linear_loss(self, state):        
+        loss_pos = np.sum([w for (i,j,w) in self.edges_positive if state[i] != state[j]])
+        loss_neg = np.sum([abs(w) for (i,j,w) in self.edges_negative if state[i] == state[j]])        
+        loss = loss_pos + loss_neg
+        return loss
+
+    def binary_loss(self, state):        
+        loss_pos = len([1 for (i,j,w) in self.edges_positive if state[i] != state[j]])
+        loss_neg = len([1 for (i,j,w) in self.edges_negative if state[i] == state[j]])
+        if self.signs==['pos', 'neg']:
+            loss = loss_pos + loss_neg        
+        elif self.signs==['pos']:
+            loss = loss_pos        
+        elif self.signs==['neg']:
+            loss = loss_neg
+        else:
+            loss = float('nan')
+        return loss
+
+    def binary_loss_poles(self, state):
+        loss_min = len([1 for (i,j,w) in self.edges_min if state[i] == state[j]])
+        loss_max = len([1 for (i,j,w) in self.edges_max if state[i] != state[j]])
+        if self.signs==['min', 'max']:
+            loss = loss_min + loss_max        
+        elif self.signs==['min']:
+            loss = loss_min        
+        elif self.signs==['max']:
+            loss = loss_max
+        else:
+            loss = float('nan')
+        return loss
+
+    def optimize_simulated_annealing(self, n, classes, nodes, init_state, max_attempts, max_iters):
+
+        # Important to reseed to have different seeds in different pool processes
+        np.random.seed()
+        
+        # Initialize custom fitness function object
+        fitness_fn = mlrose_hiive.CustomFitness(self.fitness_fn)
+
+        l2s_ = defaultdict(lambda: [])
+
+        # With initial state
+        max_val = max(n,len(classes))
+        problem = mlrose_hiive.DiscreteOpt(length = len(nodes), fitness_fn = fitness_fn, maximize = False, max_val = max_val)
+
+        # Define decay schedule
+        schedule = mlrose_hiive.ExpDecay()
+        # Solve problem using simulated annealing
+        best_state, best_fitness, _ = mlrose_hiive.simulated_annealing(problem, schedule = schedule, init_state = init_state, max_attempts = max_attempts, max_iters = max_iters)
+
+        l2s_[best_fitness].append((best_state,max_val))
+
+        # Important to reseed to have different seeds in different pool processes
+        np.random.seed()
+        
+        # Repeat without initial state
+        max_val = n
+        problem = mlrose_hiive.DiscreteOpt(length = len(nodes), fitness_fn = fitness_fn, maximize = False, max_val = max_val)
+
+        schedule = mlrose_hiive.ExpDecay()
+        best_state, best_fitness, _ = mlrose_hiive.simulated_annealing(problem, schedule = schedule, max_attempts = max_attempts, max_iters = max_iters)
+
+        l2s_[best_fitness].append((best_state,max_val))
+
+        return dict(l2s_)

--- a/languagechange/models/meaning/clustering.py
+++ b/languagechange/models/meaning/clustering.py
@@ -438,7 +438,7 @@ class CorrelationClustering():
                 node2cluster[node] = c_idx
         return node2cluster
 
-    def cluster_correlation_search(self, G, s = 10, max_attempts = 200, max_iters = 5000, initial = [], split_flag = True):
+    def cluster_correlation_search(self, G, s = 10, max_attempts = 2000, max_iters = 50000, initial = [], split_flag = True):
         """
         Apply correlation clustering. Assumes that negative edges have weights < 0, and positive edges have weights >= 0, that edges with nan have been removed and that weights are stored under edge attribute G[i][j]['weight'].
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,9 @@ trankit
 openai
 langchain
 pydantic
+networkx
+scipy
+six
+joblib==1.2
+pandas
+mlrose-hiive


### PR DESCRIPTION
This PR adds

- Annotating usages in DWUGs using computational models
- Correlation clustering from judgments (by models or humans) using the script at [https://github.com/Garrafao/correlation_clustering/blob/main/src/correlation.py](https://github.com/Garrafao/correlation_clustering/blob/main/src/correlation.py)
- Loading of DWUGs as networkx graphs from judgment and cluster files
- Plotting of DWUGs as networkx graphs (usage id:s, judgments and clusters/senses if applicable)
- Some simplification of the code for loading DWUGs and casting to other datasets