### PR TITLE
Feature/semeval get word usages

### DIFF
--- a/languagechange/benchmark.py
+++ b/languagechange/benchmark.py
@@ -4,6 +4,7 @@ import re
 import json
 import webbrowser
 import pickle
+import hashlib
 import math
 from math import comb
 import csv
@@ -27,9 +28,10 @@ from languagechange.corpora import LinebyLineCorpus
 from languagechange.models.representation.contextualized import ContextualizedModel
 from languagechange.models.representation.definition import DefinitionGenerator
 from languagechange.models.representation.prompting import PromptModel
-from languagechange.usages import Target, TargetUsage, TargetUsageList, DWUGUsage
+from languagechange.usages import Target, TargetUsage, TargetUsageList, DWUGUsage, UsageDictionary
 from languagechange.utils import NumericalTime, LiteralTime, generate_colormap
 from languagechange.models.meaning.clustering import Clustering, CorrelationClustering
+from languagechange.cache import CacheManager
 
 
 def purity(labels_true, cluster_labels):
@@ -67,6 +69,17 @@ def generate_index_pairs(total, n, random_seed=None):
     # Pick the second in the pair
     c2 = selected - sum_c1_indices + c1 + 1
     return np.stack([c1, c2]).astype(int).transpose()
+
+
+def generate_cache_key(data):
+    """
+    Generate a unique cache key based on the input data.
+    """
+    try:
+        serialized = pickle.dumps(data)
+        return hashlib.sha256(serialized).hexdigest()
+    except Exception as e:
+        raise ValueError(f"Invalid input: {e}")
 
 
 class Benchmark():
@@ -228,6 +241,19 @@ class SemanticChangeEvaluationDataset(Benchmark):
 class SemEval2020Task1(SemanticChangeEvaluationDataset):
 
     def __init__(self, language, subset: int = None, config='opt'):
+        """
+        Initialize a SemEval2020Task1 dataset instance.
+
+        Depending on the selected language, this class loads one of three lexical semantic change benchmarks:
+        - SemEval 2020 Task 1 (EN, DE, SV, LA)
+        - NorDiaChange (NO)
+        - RuShiftEval (RU)
+
+        Parameters:
+            language (str): language code of the dataset to load.
+            subset (int, optional): dataset subset to use for NorDiaChange and RuShiftEval. Ignored for other languages.
+            config (str, default="opt"): Configuration of the NorDiaChange statistics to load. Ignored for other datasets.
+        """
         lc = LanguageChange()
         self.language = language
         if self.language == 'NO' or self.language == 'RU':
@@ -245,6 +271,17 @@ class SemEval2020Task1(SemanticChangeEvaluationDataset):
         self.load()
 
     def load(self):
+        """
+        Load corpus resources, target words, and gold semantic change labels.
+
+        For SemEval 2020 Task 1, both tokenized and lemmatized corpora are initialized together with binary and graded 
+        change annotations.
+
+        For NorDiaChange, usage statistics and change scores are loaded from the selected subset.
+
+        For RuShiftEval, graded semantic change scores are loaded from the selected annotation subset. Since 
+        RuShiftEval reports semantic relatedness (COMPARE) rather than semantic change directly, scores are negated.
+        """
         if self.dataset == "SemEval 2020 Task 1":
             self.corpus1_lemma = LinebyLineCorpus(
                 os.path.join(self.home_path, 'corpus1', 'lemma'),
@@ -313,8 +350,114 @@ class SemEval2020Task1(SemanticChangeEvaluationDataset):
                     self.target_words.add(word)
                     word = Target(word)
                     self.graded_task[word] = float(score)
+    
+    def _search_for_usages(self,
+        words,
+        group='all', 
+        lemma=True, 
+        cache=True, 
+        usage_cache_dir="~/.cache/languagechange/usages"
+        ):
+        """
+        Search the SemEval corpora for usages of one or more target words.
 
-    def get_word_usages(self, word, group='all'):
+        This method is only applicable to the original SemEval 2020 Task 1
+        datasets (EN, DE, SV, and LA). Results may optionally be cached to
+        avoid repeated corpus searches.
+
+        Args:
+            words (Union[str, list[str]]): target word or collection of target words.
+            group (str, default="all"): the time period to use ('1','2', or 'all')
+            lemma (bool, default=True): if True, search the lemmatized corpora. Otherwise search the tokenized corpora.
+            cache (bool, default=True): whether cached search results should be used and updated.
+            usage_cache_dir (str, default="~/.cache/languagechange/usages"): directory used for storing cached search 
+                results.
+
+        Returns
+            dict[str, TargetUsageList]: Dictionary mapping each queried word to its list of usages from the corpus
+                /corpora.
+        """
+        if self.dataset != 'SemEval 2020 Task 1':
+            logging.error("Only SemEval 2020 Task 1 datasets (languages EN, DE, SV and LA) can be searched through.")
+            raise ValueError
+        if isinstance(words, str):
+            words = [words]
+        usage_list = []
+        corpora = []
+        if lemma:
+            if str(group) in ['1','all']:
+                corpora.append(self.corpus1_lemma)
+            if str(group) in ['2','all']:
+                corpora.append(self.corpus2_lemma)
+        else:
+            if str(group) in ['1','all']:
+                corpora.append(self.corpus1_token)
+            if str(group) in ['2','all']:
+                corpora.append(self.corpus2_token)
+        
+        for corpus in corpora:
+            search = True
+            if cache:
+                cache_mgr = CacheManager(cache_dir=usage_cache_dir)
+                # Generate cache key
+                cache_key = generate_cache_key((self.dataset, self.language, corpus, list(words)))
+                cache_path = os.path.join(cache_mgr.cache_dir,
+                                            f"{self.dataset}_{self.language}_{cache_key}.json")
+
+                # whether the cache files exist
+                if os.path.exists(cache_path):
+                    try:
+                        logging.info(f"Loading cached usages from {cache_path}")
+                        with open(cache_path, "r") as f:
+                            corpus_usages = json.load(f)
+                            # When loading from cache, replace 'text_' with 'text'.
+                            corpus_usages = UsageDictionary(
+                                {w: TargetUsageList(
+                                    [TargetUsage(**({"text": tu.pop("text_")} | tu)) for tu in tul])
+                                    for w, tul in corpus_usages.items()})
+                            search = False
+                    except FileNotFoundError as e:
+                        logging.error(f"Cache loading failed: {str(e)}, deleting corrupted cache file...")
+                        os.remove(cache_path)
+
+            if search:
+                logging.info(f"Searching for usages in {corpus.name}...")
+                corpus_usages = corpus.search(words)
+                # Remove 'token=' or 'lemma='
+                corpus_usages = {st.split("=")[-1]: us for st, us in corpus_usages.items()}
+                if cache_mgr:
+                    # save the usages to a json file
+                    with cache_mgr.atomic_write(cache_path, mode='w') as temp_path:
+                        serialized = {w: corpus_usages[w].to_dict() for w in corpus_usages.keys()}
+                        json.dump(serialized, temp_path)
+                        logging.info(f"Saved usages to {cache_path}.")
+            usage_list.append(corpus_usages)
+        return {w: TargetUsageList(usage_list[0][w] + usage_list[1][w]) for w in words}
+
+
+    def get_word_usages(self, 
+            word, 
+            group='all', 
+            lemma=True, 
+            cache=True, 
+            usage_cache_dir="~/.cache/languagechange/usages"):
+        """
+        Retrieve all recorded usages of a target word.
+
+        Args:
+            word (str): target word.
+            group (str, default="all"): group (time period) to retrieve usages from. Selecting '1' and '2' returns the 
+                usages of the first and second time period, respectively. The value "all" returns every available 
+                usage.
+            lemma (bool, default=True): for SemEval datasets, search the lemmatized corpus instead of the tokenized 
+                corpus.
+            cache (bool, default=True): whether corpus search results should be cached (for SemEval datasets).
+            usage_cache_dir (str, default="~/.cache/languagechange/usages"): directory containing cached search results.
+                (for SemEval datasets).
+
+        Returns:
+            TargetUsageList: all usages corresponding to the requested target word.
+        """
         group = str(group)
         usages = TargetUsageList()
 
@@ -349,15 +492,56 @@ class SemEval2020Task1(SemanticChangeEvaluationDataset):
             column_ids = list(df)
             for _, row in df.iterrows():
                 u = {c: row[c] for c in column_ids}
-                u['text'] = u['context']
-                u['target'] = Target(u['lemma'])
-                u['target'].set_lemma(u['lemma'])
-                u['target'].set_pos(u['pos'])
-                u['offsets'] = [int(i) for i in u['indexes_target_token'].split(':')]
-                u['time'] = NumericalTime(u['date'])
-                usages.append(DWUGUsage(**u))
-
+                if group == 'all' or u['grouping'] == group:
+                    u['text'] = u['context']
+                    u['target'] = Target(u['lemma'])
+                    u['target'].set_lemma(u['lemma'])
+                    u['target'].set_pos(u['pos'])
+                    u['offsets'] = [int(i) for i in u['indexes_target_token'].split(':')]
+                    u['time'] = NumericalTime(u['date'])
+                    usages.append(DWUGUsage(**u))
+        
+        else:
+            usage_dict = self._search_for_usages(
+                words=[word], 
+                group=group, 
+                lemma=lemma, 
+                cache=cache, 
+                usage_cache_dir=usage_cache_dir)
+            usages = usage_dict[word]
+        
         return usages
+
+    def get_all_usages(self,
+            group='all', 
+            lemma=True, 
+            cache=True, 
+            usage_cache_dir="~/.cache/languagechange/usages"):
+        """
+        Retrieve all recorded usages of all target words in the dataset.
+
+        Args:
+            group (str, default="all"): group (time period) to retrieve usages from. Selecting '1' and '2' returns the 
+                usages of the first and second time period, respectively. The value "all" returns every available 
+                usage.
+            lemma (bool, default=True): for SemEval datasets, search the lemmatized corpus instead of the tokenized 
+                corpus.
+            cache (bool, default=True): whether corpus search results should be cached (for SemEval datasets).
+            usage_cache_dir (str, default="~/.cache/languagechange/usages"): directory containing cached search results.
+                (for SemEval datasets).
+
+        Returns:
+            TargetUsageList: all usages corresponding to the requested target word.
+        """
+        if self.dataset == "SemEval 2020 Task 1":
+            return self._search_for_usages(
+                list(self.target_words), 
+                group=group, 
+                lemma=lemma, 
+                cache=cache, 
+                usage_cache_dir=usage_cache_dir)
+        else:
+            return {w: self.get_word_usages(w) for w in self.target_words}
 
 
 class DWUG(SemanticChangeEvaluationDataset):

--- a/languagechange/benchmark.py
+++ b/languagechange/benchmark.py
@@ -400,7 +400,7 @@ class SemEval2020Task1(SemanticChangeEvaluationDataset):
             if cache:
                 cache_mgr = CacheManager(cache_dir=usage_cache_dir)
                 # Generate cache key
-                cache_key = generate_cache_key((self.dataset, self.language, corpus, list(words)))
+                cache_key = generate_cache_key((self.dataset, self.language, corpus.name, sorted(words)))
                 cache_path = os.path.join(cache_mgr.cache_dir,
                                             f"{self.dataset}_{self.language}_{cache_key}.json")
 

--- a/languagechange/models/representation/prompting.py
+++ b/languagechange/models/representation/prompting.py
@@ -7,7 +7,6 @@ from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from jsonschema import ValidationError
 import logging
-from trankit.pipeline import Pipeline
 
 
 class SCFloat(BaseModel):

--- a/languagechange/pipeline.py
+++ b/languagechange/pipeline.py
@@ -3,8 +3,6 @@ from collections import Counter, deque
 from datetime import datetime
 import math
 import json
-import pickle
-import hashlib
 import logging
 import inspect
 import os
@@ -47,17 +45,6 @@ def get_depth(d):
     if not isinstance(d, dict):
         return 0
     return 1 + max([get_depth(v) for v in d.values()])
-
-
-def generate_cache_key(data):
-    """
-    Generate a unique cache key based on the input data.
-    """
-    try:
-        serialized = pickle.dumps(data)
-        return hashlib.sha256(serialized).hexdigest()
-    except Exception as e:
-        raise ValueError(f"Invalid input: {e}")
 
 
 class WiCBinary(BaseModel):
@@ -958,46 +945,10 @@ class CDPipeline(Pipeline):
             all_words = set(self.dataset.keys())
 
         if isinstance(self.dataset, SemEval2020Task1) and self.dataset.dataset not in {"NorDiaChange", "RuShiftEval"}:
-            usage_list = []
-            for corpus in [self.dataset.corpus1_lemma, self.dataset.corpus2_lemma]:
-                search = True
-                if self.cache_mgr:
-                    # Generate cache key
-                    cache_key = generate_cache_key((self.dataset.dataset, self.dataset.language, corpus))
-                    cache_path = os.path.join(self.cache_mgr.cache_dir,
-                                              f"{self.dataset.dataset}_{self.dataset.language}_{cache_key}.json")
-
-                    # whether the cache files exist
-                    if os.path.exists(cache_path):
-                        try:
-                            logging.info(f"Loading cached usages from {cache_path}")
-                            with open(cache_path, "r") as f:
-                                corpus_usages = json.load(f)
-                                # When loading from cache, replace 'text_' with 'text'.
-                                corpus_usages = UsageDictionary(
-                                    {w: TargetUsageList(
-                                        [TargetUsage(**({"text": tu.pop("text_")} | tu)) for tu in tul])
-                                        for w, tul in corpus_usages.items()})
-                                search = False
-                        except Exception as e:
-                            logging.error(f"Cache loading failed: {str(e)}, deleting corrupted cache file...")
-                            os.remove(cache_path)
-
-                if search:
-                    logging.info(f"Searching for usages in {corpus.name}...")
-                    corpus_usages = corpus.search([target.target for target in self.dataset.graded_task.keys()])
-                    if self.cache_mgr:
-                        # save the usages to a json file
-                        with self.cache_mgr.atomic_write(cache_path, mode='w') as temp_path:
-                            serialized = {w: corpus_usages[w].to_dict() for w in corpus_usages.keys()}
-                            json.dump(serialized, temp_path)
-                            logging.info(f"Saved usages to {cache_path}.")
-                usage_list.append(corpus_usages)
-            for t, usages_per_word in enumerate(usage_list):
-                for w, us in usages_per_word.items():
-                    if w not in usages:
-                        usages[w] = dict()
-                    usages[w][t] = us
+            usages_per_word = self.dataset.get_all_usages()
+            # Sort by time
+            for w, us in usages_per_word.items():
+                usages[w] = us.group_by_time(use_year=False)
         
         elif (isinstance(self.dataset, DWUG) or 
              (isinstance(self.dataset, SemEval2020Task1) and self.dataset.dataset in {"NorDiaChange", "RuShiftEval"})):

--- a/languagechange/usages.py
+++ b/languagechange/usages.py
@@ -103,6 +103,7 @@ class DWUGUsage(TargetUsage):
         d['target'] = str(d['target'])
         return d
 
+
 class TargetUsageList(list):
     """List of TargetUsage instances with serialization helpers."""
 
@@ -209,12 +210,16 @@ class TargetUsageList(list):
             UsageDictionary: mapping from time labels to TargetUsageList objects.
         """
         if times and not isinstance(times, list):
-            logging.error("`times` has to be a list of Time, str or int.")
+            logging.error("If not None, `times` has to be a list of Time, str or int.")
             raise TypeError
         if times is None:
             if use_year:
-                sorted_times = sorted(set(_parse_year(getattr(u, time_attr)) for u in self))
-            else:
+                try:
+                    sorted_times = sorted(set(_parse_year(getattr(u, time_attr)) for u in self))
+                except ValueError:
+                    logging.info(f"Could not parse the '{time_attr}' attributes as years. Falling back to using '{time_attr}' directly.")
+                    use_year = False
+            if not use_year:
                 sorted_times = sorted(set(str(getattr(u, time_attr)) for u in self))
             intervals = [TimeInterval(LiteralTime(str(y)), LiteralTime(str(y))) for y in sorted_times]
         else:
@@ -223,17 +228,24 @@ class TargetUsageList(list):
             intervals = [TimeInterval(t, t) for t in times]
         return self.group_by_interval(intervals, time_attr=time_attr, use_year=use_year)
 
-    def _sample(self, generator, n_samples):
+    def sample(self, n_samples, random_seed=None):
+        """
+        Sample N usages randomly from the list of usages.
+
+        Args:
+            n_samples (int): the amount of usages to sample
+            random_seed (Union[int, NoneType], default=None): the random seed to use. Set one for reproducibility.
+        """
+        rng = np.random.default_rng(seed=random_seed)
         if n_samples < len(self) and n_samples != 0:
-            return generator.choice(self, size=n_samples, replace=False).tolist()
+            return rng.choice(self, size=n_samples, replace=False).tolist()
         return self
 
     def _group_and_sample(self, groups, grouping_fn, n_samples=0, random_seed=None, time_attr="time", use_year=False):
-        rng = np.random.default_rng(seed=random_seed)
         sampled = TargetUsageList()
         usages_by_group = grouping_fn(groups, time_attr=time_attr, use_year=use_year)
         for _, g_usages in sorted(usages_by_group.items(), key = lambda i : i[0]):
-            sampled.extend(g_usages._sample(rng, n_samples))
+            sampled.extend(g_usages.sample(n_samples, random_seed=random_seed))
         return sampled
 
     def sample_per_interval(self, intervals, n_samples=0, random_seed=None, time_attr="time", use_year=False):

--- a/languagechange/usages.py
+++ b/languagechange/usages.py
@@ -46,10 +46,20 @@ class Target:
 class TargetUsage:
     """Represents an individual usage with offsets and optional time metadata."""
 
-    def __init__(self, text: str, offsets: str, time: Time = None, **kwargs):
+    def __init__(self, text: str, offsets: str, time: Union[Time, str, int] = None, **kwargs):
         self.text_ = text
         self.offsets = offsets
-        self.time = time
+        if isinstance(time, str):
+            self.time = LiteralTime(time)
+        elif isinstance(time, int):
+            self.time = NumericalTime(time)
+        elif isinstance(time, Time):
+            self.time = time
+        elif time is not None:
+            logging.error("'time' has to be a NumericalTime, LiteralTime, str, int or None.")
+            raise TypeError
+        else:
+            time = self.time
         self.__dict__.update(kwargs)
 
     def text(self):
@@ -130,6 +140,9 @@ class TargetUsageList(list):
             UsageDictionary: mapping from interval strings to TargetUsageList objects containing the usages that fall 
                 within each interval.
         """
+        if not all(getattr(u, time_attr, None) for u in self):
+            logging.error(f"In order to sort by '{time_attr}', all usages need to have a '{time_attr}' attribute.")
+            raise AttributeError
         if not isinstance(intervals, list):
             logging.error("`intervals` has to be a list of TimeInterval or tuples of str or int.")
             raise TypeError

--- a/languagechange/utils.py
+++ b/languagechange/utils.py
@@ -93,7 +93,7 @@ class TimeInterval(Time):
     def __lt__(self, other):
         if type(other) == TimeInterval:
             if self.start == other.start:
-                return self.duration < other.duration
+                return self.end < other.end
             else:
                 return self.start < other.start
         elif type(other) == NumericalTime:
@@ -102,7 +102,7 @@ class TimeInterval(Time):
     def __le__(self, other):
         if type(other) == TimeInterval:
             if self.start == other.start:
-                return self.duration <= other.duration
+                return self.end <= other.end
             else:
                 return self.start <= other.start
         elif type(other) == NumericalTime:


### PR DESCRIPTION
This PR

- moves the searching for word usages in CDPipeline to the SemEval2020Task1 class itself
- adapts the get_word_usages method of SemEval2020Task1 to use this search, to allow the user to get usages of one or more words for all SemEval2020Task1 datasets, not only NO and RU
- adds a get_all_usages method to the same class
- makes the _sample method of TargetUsageList public-facing to allow the user to sample N usages from a list of target usages, irrespective of their time
- fixes some bugs in loading cached target usages